### PR TITLE
Provide Apollo context to SchemaLink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-tests/
 coverage/
 .nyc_output/
 
+.vscode
 .DS_Store
 npm-debug.log
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.10.0",
     "flow-bin": "0.75.0",
-    "fusion-apollo": "^1.1.0",
+    "fusion-apollo": "^1.2.0-0",
     "fusion-core": "1.4.1",
     "fusion-react-async": "1.2.2",
     "fusion-tokens": "^1.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,12 @@ const ApolloClientPlugin = createPlugin({
       const connectionLink =
         schema && __NODE__
           ? new SchemaLink({
-            schema,
-            context: typeof apolloContext === 'function' ? apolloContext(ctx) : apolloContext,
-          })
+              schema,
+              context:
+                typeof apolloContext === 'function'
+                  ? apolloContext(ctx)
+                  : apolloContext,
+            })
           : new HttpLink({
               uri: endpoint,
               fetch,

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const ApolloClientPlugin = createPlugin({
     fetch: FetchToken,
     authKey: ApolloClientAuthKeyToken.optional,
     schema: GraphQLSchemaToken.optional,
-    context: ApolloContextToken.optional,
+    apolloContext: ApolloContextToken.optional,
   },
   provides({endpoint, fetch, authKey = 'token', context, schema}) {
     return (ctx, initialState) => {
@@ -49,7 +49,7 @@ const ApolloClientPlugin = createPlugin({
         schema && __NODE__
           ? new SchemaLink({
             schema,
-            apolloContext: typeof context === 'function' ? context(ctx) : context,
+            context: typeof apolloContext === 'function' ? apolloContext(ctx) : apolloContext,
           })
           : new HttpLink({
               uri: endpoint,

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const ApolloClientPlugin = createPlugin({
         schema && __NODE__
           ? new SchemaLink({
             schema,
-            context: typeof context === 'function' ? context(ctx) : context,
+            apolloContext: typeof context === 'function' ? context(ctx) : context,
           })
           : new HttpLink({
               uri: endpoint,

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const ApolloClientPlugin = createPlugin({
     schema: GraphQLSchemaToken.optional,
     apolloContext: ApolloContextToken.optional,
   },
-  provides({endpoint, fetch, authKey = 'token', context, schema}) {
+  provides({endpoint, fetch, authKey = 'token', apolloContext, schema}) {
     return (ctx, initialState) => {
       const getBrowserProps = () => {
         return Cookies.get(authKey);

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
 
 import {createPlugin, createToken} from 'fusion-core';
 import {FetchToken} from 'fusion-tokens';
-import {GraphQLSchemaToken} from 'fusion-apollo';
+import {GraphQLSchemaToken, ApolloContextToken} from 'fusion-apollo';
 import {ApolloClient} from 'apollo-client';
 import {HttpLink} from 'apollo-link-http';
 import {ApolloLink, concat} from 'apollo-link';
@@ -33,8 +33,9 @@ const ApolloClientPlugin = createPlugin({
     fetch: FetchToken,
     authKey: ApolloClientAuthKeyToken.optional,
     schema: GraphQLSchemaToken.optional,
+    context: ApolloContextToken.optional,
   },
-  provides({endpoint, fetch, authKey = 'token', schema}) {
+  provides({endpoint, fetch, authKey = 'token', context, schema}) {
     return (ctx, initialState) => {
       const getBrowserProps = () => {
         return Cookies.get(authKey);
@@ -46,7 +47,10 @@ const ApolloClientPlugin = createPlugin({
 
       const connectionLink =
         schema && __NODE__
-          ? new SchemaLink({schema})
+          ? new SchemaLink({
+            schema,
+            context: typeof context === 'function' ? context(ctx) : context,
+          })
           : new HttpLink({
               uri: endpoint,
               fetch,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,11 +2640,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-apollo@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fusion-apollo/-/fusion-apollo-1.1.0.tgz#017c055697d36add22716aa78c5b9f50eb1d6279"
+fusion-apollo@^1.2.0-0:
+  version "1.2.0-0"
+  resolved "https://registry.yarnpkg.com/fusion-apollo/-/fusion-apollo-1.2.0-0.tgz#4ce3ff5624544e7775b32c3ea114ad2a3c06d851"
   dependencies:
-    fusion-react "^1.0.4"
+    fusion-react "^1.0.5"
 
 fusion-core@1.4.1:
   version "1.4.1"
@@ -2676,7 +2676,7 @@ fusion-react-async@1.2.2:
     prop-types "^15.5.8"
     react-is "^16.3.1"
 
-fusion-react@^1.0.4:
+fusion-react@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.0.5.tgz#478e5db3d49379d10ec9a072822a0e7b6092e036"
 


### PR DESCRIPTION
There currently isn't a way to configure the Apollo context (provided to resolvers).

This PR consumes the context token exported by `fusion-apollo` in https://github.com/fusionjs/fusion-apollo/pull/86, and passes the provided context to the `SchemaLink` when using SSR.