### PR TITLE
Disable ssrMode client side

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,14 @@ const ApolloClientPlugin = createPlugin({
         ssrMode: __NODE__ ? true : false,
         link: apolloLinkFrom(links),
         cache: new InMemoryCache().restore(initialState),
+        defaultOptions: {
+          watchQuery: {
+            fetchPolicy: 'network-only',
+          },
+          query: {
+            fetchPolicy: 'cache-and-network',
+          },
+        },
       });
       return client;
     };

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ const ApolloClientPlugin = createPlugin({
         links.unshift(apolloLink);
       }
       const client = new ApolloClient({
-        ssrMode: true,
+        ssrMode: __NODE__ ? true : false,
         link: apolloLinkFrom(links),
         cache: new InMemoryCache().restore(initialState),
       });


### PR DESCRIPTION
`pullInterval` does not work when `ssrMode` is true on the client.