### PR TITLE
Add ApolloClientCacheToken for specifying and utilizing a cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Apollo Client is the entrypoint for most Apollo applications. This plugin pr
   - [Dependencies](#dependencies)
     - [`FetchToken`](#fetchtoken)
     - [`ApolloClientAuthKeyToken`](#apolloclientauthkeytoken)
+    - [`ApolloClientCacheToken`](#apolloclientcachetoken)
     - [`ApolloClientCredentialsToken`](#apolloclientcredentialstoken)
     - [`ApolloClientLinkToken`](#ApolloClientLinkToken)
 - [Examples](#examples)
@@ -138,6 +139,22 @@ import {ApolloClientAuthKeyToken} from 'fusion-tokens';
 ###### Default value
 
 If no token name is provided, authorization headers are not sent.
+
+##### `ApolloClientCacheToken`
+
+```js
+import {ApolloClientCacheToken} from 'fusion-tokens';
+```
+
+(Optional) A configuration value that provides the an Apollo [cache implementation](https://www.apollographql.com/docs/react/advanced/caching.html).
+
+###### Type
+
+- `mixed` - Optional.
+
+###### Default value
+
+The default value is `same-origin`.
 
 ##### `ApolloClientCredentialsToken`
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ import {ApolloClientCacheToken} from 'fusion-tokens';
 
 ###### Default value
 
-The default value is `same-origin`.
+The default cache implementation uses [InMemoryCache](https://github.com/apollographql/apollo-client/tree/master/packages/apollo-cache-inmemory).
 
 ##### `ApolloClientCredentialsToken`
 

--- a/src/__tests__/exports.js
+++ b/src/__tests__/exports.js
@@ -8,6 +8,7 @@
 
 import test from 'tape-cup';
 import ApolloClientPlugin, {
+  ApolloClientCacheToken,
   ApolloClientCredentialsToken,
   ApolloClientEndpointToken,
   ApolloClientAuthKeyToken,
@@ -16,6 +17,7 @@ import ApolloClientPlugin, {
 
 test('exports', t => {
   t.ok(ApolloClientPlugin, 'exports ApolloClientPlugin');
+  t.ok(ApolloClientCacheToken, 'exports ApolloClientCacheToken');
   t.ok(ApolloClientCredentialsToken, 'exports ApolloClientCredentialsToken');
   t.ok(ApolloClientEndpointToken, 'exports ApolloClientEndpointToken');
   t.ok(ApolloClientAuthKeyToken, 'exports ApolloClientAuthKeyToken');

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -8,6 +8,7 @@
 
 import tape from 'tape-cup';
 
+import {InMemoryCache} from 'apollo-cache-inmemory';
 import App, {createPlugin} from 'fusion-core';
 import {getSimulator} from 'fusion-test-utils';
 import {ApolloClientToken} from 'fusion-apollo';
@@ -37,6 +38,12 @@ tape('link - via app.register', async t => {
         const client = universalClient();
         // $FlowFixMe
         t.ok(client.link);
+        t.ok(
+          // $FlowFixMe
+          client.cache instanceof InMemoryCache,
+          'default cache is an instance of InMemoryCache'
+        );
+
         t.end();
         return next();
       };

--- a/src/index.js
+++ b/src/index.js
@@ -22,11 +22,16 @@ import {InMemoryCache} from 'apollo-cache-inmemory';
 
 import * as Cookies from 'js-cookie';
 
-export const ApolloClientEndpointToken: Token<string> = createToken(
-  'ApolloClientEndpointToken'
-);
+export const ApolloClientCacheToken: Token<{
+  restore: mixed => void,
+}> = createToken('ApolloClientCacheToken');
+
 export const ApolloClientCredentialsToken: Token<string> = createToken(
   'ApolloClientCredentialsToken'
+);
+
+export const ApolloClientEndpointToken: Token<string> = createToken(
+  'ApolloClientEndpointToken'
 );
 
 export const ApolloClientLinkToken: Token<{
@@ -37,6 +42,7 @@ export const ApolloClientAuthKeyToken = createToken('ApolloClientAuthKeyToken');
 
 const ApolloClientPlugin = createPlugin({
   deps: {
+    cache: ApolloClientCacheToken.optional,
     endpoint: ApolloClientEndpointToken,
     fetch: FetchToken,
     includeCredentials: ApolloClientCredentialsToken.optional,
@@ -46,6 +52,7 @@ const ApolloClientPlugin = createPlugin({
     schema: GraphQLSchemaToken.optional,
   },
   provides({
+    cache = new InMemoryCache(),
     endpoint,
     fetch,
     authKey = 'token',
@@ -97,7 +104,7 @@ const ApolloClientPlugin = createPlugin({
       const client = new ApolloClient({
         ssrMode: __NODE__ ? true : false,
         link: apolloLinkFrom(links),
-        cache: new InMemoryCache().restore(initialState),
+        cache: cache.restore(initialState),
         defaultOptions: {
           watchQuery: {
             fetchPolicy: 'network-only',


### PR DESCRIPTION
Defaults to the memory cache, but allows folks to utilize their own cache if desired.