### PR TITLE
Allow array of apollo-links to concat with existing link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export const ApolloClientCredentialsToken: Token<string> = createToken(
   'ApolloClientCredentialsToken'
 );
 
-export const ApolloClientLinkToken: Token<any> = createToken('ApolloClientLinkToken');
+export const GetApolloClientLinksToken: Token<any> = createToken('GetApolloClientLinksToken');
 
 export const ApolloClientAuthKeyToken = createToken('ApolloClientAuthKeyToken');
 
@@ -40,7 +40,7 @@ const ApolloClientPlugin = createPlugin({
     includeCredentials: ApolloClientCredentialsToken.optional,
     authKey: ApolloClientAuthKeyToken.optional,
     apolloContext: ApolloContextToken.optional,
-    apolloLink: ApolloClientLinkToken.optional,
+    getApolloLinks: GetApolloClientLinksToken.optional,
     schema: GraphQLSchemaToken.optional,
   },
   provides({
@@ -49,7 +49,7 @@ const ApolloClientPlugin = createPlugin({
     authKey = 'token',
     includeCredentials = 'same-origin',
     apolloContext,
-    apolloLink,
+    getApolloLinks,
     schema,
   }) {
     return (ctx, initialState) => {
@@ -90,12 +90,10 @@ const ApolloClientPlugin = createPlugin({
       });
       const links = [authMiddleware];
       let terminalLink = connectionLink;
-      if (apolloLink && typeof(apolloLink) === 'function') {
-        links.push(apolloLink(terminalLink));
-        terminalLink = links[links.length - 1];
+      if (getApolloLinks && typeof(getApolloLinks) === 'function') {
+        links = links.concat(getApolloLinks(terminalLink));
       } else {
         links.push(connectionLink); 
-        terminalLink = connectionLink;
       }
       const client = new ApolloClient({
         ssrMode: __NODE__ ? true : false,

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ const ApolloClientPlugin = createPlugin({
       const links = [authMiddleware];
       let terminalLink = connectionLink;
       if (getApolloLinks && typeof(getApolloLinks) === 'function') {
-        links = links.concat(getApolloLinks(terminalLink));
+        links = links.concat(getApolloLinks(connectionLink));
       } else {
         links.push(connectionLink); 
       }

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export const ApolloClientCredentialsToken: Token<string> = createToken(
   'ApolloClientCredentialsToken'
 );
 
-export const ApolloClientLinkToken: Token<{any}> = createToken('ApolloClientLinkToken');
+export const ApolloClientLinkToken: Token<any> = createToken('ApolloClientLinkToken');
 
 export const ApolloClientAuthKeyToken = createToken('ApolloClientAuthKeyToken');
 

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,11 @@ const ApolloClientPlugin = createPlugin({
         return forward(operation);
       });
       
-      const links = getApolloLinks([authMiddleware, connectionLink]);  
+      const originalLinks = [authMiddleware, connectionLink];
+      
+      const links = getApolloLinks && typeof(getApolloLinks) === 'function'
+                    ? getApolloLinks(originalLinks)
+                    : originalLinks;
       
       const client = new ApolloClient({
         ssrMode: __NODE__ ? true : false,

--- a/src/index.js
+++ b/src/index.js
@@ -88,12 +88,9 @@ const ApolloClientPlugin = createPlugin({
 
         return forward(operation);
       });
-      let links = [authMiddleware];
-      if (getApolloLinks && typeof(getApolloLinks) === 'function') {
-        links = links.concat(getApolloLinks(connectionLink));
-      } else {
-        links.push(connectionLink); 
-      }
+      
+      const links = getApolloLinks([authMiddleware, connectionLink]);  
+      
       const client = new ApolloClient({
         ssrMode: __NODE__ ? true : false,
         link: apolloLinkFrom(links),

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const ApolloClientPlugin = createPlugin({
 
         return forward(operation);
       });
-      const links = [authMiddleware];
+      let links = [authMiddleware];
       if (getApolloLinks && typeof(getApolloLinks) === 'function') {
         links = links.concat(getApolloLinks(connectionLink));
       } else {

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,6 @@ const ApolloClientPlugin = createPlugin({
         return forward(operation);
       });
       const links = [authMiddleware];
-      let terminalLink = connectionLink;
       if (getApolloLinks && typeof(getApolloLinks) === 'function') {
         links = links.concat(getApolloLinks(connectionLink));
       } else {

--- a/src/index.js
+++ b/src/index.js
@@ -29,9 +29,7 @@ export const ApolloClientCredentialsToken: Token<string> = createToken(
   'ApolloClientCredentialsToken'
 );
 
-export const ApolloClientLinkToken: Token<{
-  request: (operation: any, forward: any) => any,
-}> = createToken('ApolloClientLinkToken');
+export const ApolloClientLinkToken: Token<{any}> = createToken('ApolloClientLinkToken');
 
 export const ApolloClientAuthKeyToken = createToken('ApolloClientAuthKeyToken');
 
@@ -90,9 +88,14 @@ const ApolloClientPlugin = createPlugin({
 
         return forward(operation);
       });
-      const links = [authMiddleware, connectionLink];
-      if (apolloLink) {
-        links.unshift(apolloLink);
+      const links = [authMiddleware];
+      let terminalLink = connectionLink;
+      if (apolloLink && typeof(apolloLink) === 'function') {
+        links.push(apolloLink(terminalLink));
+        terminalLink = links[links.length - 1];
+      } else {
+        links.push(connectionLink); 
+        terminalLink = connectionLink;
       }
       const client = new ApolloClient({
         ssrMode: __NODE__ ? true : false,


### PR DESCRIPTION
There're two things to consider:
- Instead of passing a single `apollo-link`, we pass an array of `apollo-links` to concat with existing `auth-link`
- Instead of `apolloLink`, we use a function `getApolloLinks` , and pass current `connectionLink` as argument.