### PR TITLE
Release v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion-apollo-universal-client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "./dist/index.js",
   "license": "MIT",
   "repository": "fusionjs/fusion-apollo-universal-client",


### PR DESCRIPTION
- Set connectToDevTools for Apollo developer tools ([#144](https://github.com/fusionjs/fusion-apollo-universal-client/pull/144))