### PR TITLE
Support getting token via querystring on server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ const ApolloClientPlugin = createPlugin({
       };
 
       const getServerProps = () => {
-        return ctx && ctx.cookies.get(authKey);
+        return ctx && (ctx.cookies.get(authKey) || ctx.query[authKey]);
       };
 
       const connectionLink =


### PR DESCRIPTION
In case `Fusion` app is behind a reverse proxy, we could get `token` via a querystring instead of cookies.