### PR TITLE
Set ssrMode to true for both server and client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,8 @@ const ApolloClientPlugin = createPlugin({
         ? getApolloLinks([authMiddleware, connectionLink], ctx)
         : [authMiddleware, connectionLink];
       const client = new ApolloClient({
-        ssrMode: __NODE__ ? true : false,
+        // ssrMode must be set to true in order to use SSR hydrated cache.
+        ssrMode: true,
         connectToDevTools: __BROWSER__ && __DEV__,
         link: apolloLinkFrom(links),
         cache: cache.restore(initialState),


### PR DESCRIPTION
Currently when loading a page all GraphQL queries are fired twice. Setting ssrMode to true is required if we want to use the state hydrated from the SSR cache.

Currently working on an integration testing suite in #153 for this library, but running into a few issues and would like to get this landed first.