### PR TITLE
Create a new in memory cache per apollo client on the server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ const ApolloClientPlugin: FusionPlugin<
         ssrMode: true,
         connectToDevTools: __BROWSER__ && __DEV__,
         link: apolloLinkFrom(links),
-        cache: cache.restore(initialState),
+        cache: __NODE__ ? new InMemoryCache() : cache.restore(initialState),
         defaultOptions: {
           watchQuery: {
             fetchPolicy: 'network-only',


### PR DESCRIPTION
This is a hotfix for an issue where server side caches can persist across requests. A more robust solution will come after in a breaking change.

Fixes #161 
