### PR TITLE
Set "ssrMode" to false on a client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,19 +128,10 @@ const ApolloClientPlugin: FusionPlugin<
         : [authMiddleware, connectionLink];
 
       const client = new ApolloClient({
-        // ssrMode must be set to true in order to use SSR hydrated cache.
-        ssrMode: true,
+        ssrMode: __NODE__,
         connectToDevTools: __BROWSER__ && __DEV__,
         link: apolloLinkFrom(links),
         cache: cache.restore(initialState),
-        defaultOptions: {
-          watchQuery: {
-            fetchPolicy: 'network-only',
-          },
-          query: {
-            fetchPolicy: 'cache-and-network',
-          },
-        },
       });
       return client;
     }


### PR DESCRIPTION
Documentation says:

>> When using the client for server side rendering, pass ssrMode as true so that React Apollo’s getDataFromTree can work effectively.

Using true on a client breaks polling queries.

Debug:
1) Client sets ` this.disableNetworkFetches` to false.
https://github.com/apollographql/apollo-client/blob/v1.9.0/src/ApolloClient.ts#L240

2) Client overrides `fetchPolicy` to be `cache-first`
https://github.com/apollographql/apollo-client/blob/v1.9.0/src/ApolloClient.ts#L317

3) Error when trying to use `cache-first` with pollInterval
https://github.com/apollographql/apollo-client/blob/905001e40cfadf841aa5a78aa428ab09f8cdf108/packages/apollo-client/src/core/ObservableQuery.ts#L535