### PR TITLE
Remove graphql from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "license": "MIT",
   "repository": "fusionjs/fusion-apollo-universal-client",
   "module": "./dist/index.es.js",
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "browser": {
     "./dist/index.js": "./dist/browser.es5.js",
     "./dist/index.es.js": "./dist/browser.es5.es.js"
@@ -76,7 +73,6 @@
     "apollo-link": "^1.2.4",
     "apollo-link-http": "^1.5.7",
     "apollo-link-schema": "^1.1.2",
-    "graphql": "git://github.com/graphql/graphql-js.git#npm",
     "js-cookie": "^2.2.0"
   }
 }


### PR DESCRIPTION
The graphql package should be a peer/devDep only.