### PR TITLE
Set default context to fusion ctx

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ const ApolloClientPlugin: FusionPlugin<
     fetch,
     authKey = 'token',
     includeCredentials = 'same-origin',
-    apolloContext,
+    apolloContext = ctx => ctx,
     getApolloLinks,
     schema,
     defaultOptions,


### PR DESCRIPTION
This makes the most sense as a default as it allows you to use
request scoped plugins in resolvers.