### PR TITLE
Release v2.1.0-YEeqsY7ojVk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion-apollo-universal-client",
-  "version": "2.1.0-1",
+  "version": "2.1.0-YEeqsY7ojVk",
   "main": "./dist/index.js",
   "license": "MIT",
   "repository": "fusionjs/fusion-apollo-universal-client",
@@ -62,8 +62,8 @@
     "prepublish": "npm run transpile"
   },
   "peerDependencies": {
-    "fusion-core": "^1.10.1",
     "fusion-apollo": "^1.6.0-0",
+    "fusion-core": "^1.10.1",
     "fusion-tokens": "^1.1.1",
     "graphql": "^14.1.1",
     "react": "16.x",


### PR DESCRIPTION
- Update dependencies ([#189](https://github.com/fusionjs/fusion-apollo-universal-client/pull/189))
- Set default context to fusion ctx ([#187](https://github.com/fusionjs/fusion-apollo-universal-client/pull/187))
- Add default for graphql endpoint token ([#186](https://github.com/fusionjs/fusion-apollo-universal-client/pull/186))
- Add token for default options ([#185](https://github.com/fusionjs/fusion-apollo-universal-client/pull/185))