### PR TITLE
Allow to specify local state resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Apollo Client is the entrypoint for most Apollo applications. This plugin pr
     - [`GetApolloClientCacheToken`](#GetApolloClientCacheToken)
     - [`ApolloClientCredentialsToken`](#apolloclientcredentialstoken)
     - [`GetApolloClientLinksToken`](#getapolloclientlinkstoken)
+    - [`ApolloClientResolversToken`](#apolloclientresolverstoken)
 - [Examples](#examples)
 
 ---
@@ -183,5 +184,17 @@ import {GetApolloClientLinksToken} from 'fusion-apollo-universal-client';
 ###### Type
 
 - `(Array<ApolloLinkType>) => Array<ApolloLinkType>` - Optional.
+
+##### `ApolloClientResolversToken`
+
+```js
+import { ApolloClientResolversToken } from "fusion-apollo-universal-client";
+```
+
+(Optional) Provides the resolvers for [local state management](https://www.apollographql.com/docs/react/essentials/local-state.html).
+
+###### Type
+
+- `ResolverMap | $ReadOnlyArray<ResolverMap>` - Optional.
 
 ---

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "apollo-cache-inmemory": "^1.3.12",
-    "apollo-client": "^2.4.8",
+    "apollo-client": "^2.5.1",
     "apollo-link": "^1.2.6",
     "apollo-link-http": "^1.5.9",
     "apollo-link-schema": "^1.1.4",

--- a/src/__tests__/exports.js
+++ b/src/__tests__/exports.js
@@ -14,6 +14,7 @@ import ApolloClientPlugin, {
   ApolloClientAuthKeyToken,
   GetApolloClientLinksToken,
   ApolloClientDefaultOptionsToken,
+  ApolloClientResolversToken,
 } from '../index.js';
 
 test('exports', t => {
@@ -24,4 +25,5 @@ test('exports', t => {
   t.ok(ApolloClientAuthKeyToken, 'exports ApolloClientAuthKeyToken');
   t.ok(GetApolloClientLinksToken, 'exports ApolloClientAuthKeyToken');
   t.ok(ApolloClientDefaultOptionsToken, 'exports ApolloClientAuthKeyToken');
+  t.ok(ApolloClientResolversToken, 'exports ApolloClientResolversToken');
 });

--- a/src/__tests__/local-state.js
+++ b/src/__tests__/local-state.js
@@ -1,0 +1,83 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {ApolloClientToken, GraphQLSchemaToken} from 'fusion-apollo';
+import App, {createPlugin} from 'fusion-core';
+import {getSimulator, test} from 'fusion-test-utils';
+import {FetchToken} from 'fusion-tokens';
+import {buildSchema} from 'graphql';
+import gql from 'graphql-tag';
+import unfetch from 'unfetch';
+
+import ApolloClientPlugin, {ApolloClientResolversToken} from '../index.js';
+
+test('local state management', async t => {
+  const app = new App('el', el => el);
+  app.register(ApolloClientToken, ApolloClientPlugin);
+  app.register(
+    GraphQLSchemaToken,
+    (buildSchema(`
+      type Query {
+        query: String!
+      }
+
+      type Mutation {
+        mutate: String # returns nothing
+      }
+    `): any)
+  );
+  app.register(FetchToken, unfetch);
+
+  let mutationCalled = false;
+  app.register(ApolloClientResolversToken, {
+    Query: {
+      query: () => 'foo',
+    },
+    Mutation: {
+      mutate: async () => {
+        mutationCalled = true;
+      },
+    },
+  });
+
+  const testPlugin = createPlugin({
+    deps: {
+      universalClient: ApolloClientToken,
+    },
+    middleware({universalClient}) {
+      return async (ctx, next) => {
+        const client = universalClient(ctx, {});
+
+        const {data} = await client.query({
+          query: gql`
+            query {
+              query @client
+            }
+          `,
+        });
+        t.equal(data.query, 'foo');
+
+        t.equal(mutationCalled, false);
+        await client.mutate({
+          mutation: gql`
+            mutation {
+              mutate @client
+            }
+          `,
+        });
+        t.equal(mutationCalled, true);
+
+        return next();
+      };
+    },
+  });
+  app.register(testPlugin);
+
+  const simulator = getSimulator(app);
+  await simulator.render('/');
+});

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,21 @@ export const ApolloClientAuthKeyToken: Token<string> = createToken(
   'ApolloClientAuthKeyToken'
 );
 
+export const ApolloClientResolversToken: Token<
+  ResolverMapType | $ReadOnlyArray<ResolverMapType>
+> = createToken('ApolloClientResolversToken');
+
+type ResolverMapType = {
+  +[key: string]: {
+    +[field: string]: (
+      rootValue?: any,
+      args?: any,
+      context?: any,
+      info?: any
+    ) => any,
+  },
+};
+
 type ApolloClientDepsType = {
   getCache: typeof GetApolloClientCacheToken.optional,
   endpoint: typeof ApolloClientEndpointToken.optional,
@@ -58,6 +73,7 @@ type ApolloClientDepsType = {
   apolloContext: typeof ApolloContextToken.optional,
   getApolloLinks: typeof GetApolloClientLinksToken.optional,
   schema: typeof GraphQLSchemaToken.optional,
+  resolvers: typeof ApolloClientResolversToken.optional,
   defaultOptions: typeof ApolloClientDefaultOptionsToken.optional,
 };
 
@@ -81,6 +97,7 @@ const ApolloClientPlugin: FusionPlugin<
     apolloContext: ApolloContextToken.optional,
     getApolloLinks: GetApolloClientLinksToken.optional,
     schema: GraphQLSchemaToken.optional,
+    resolvers: ApolloClientResolversToken.optional,
     defaultOptions: ApolloClientDefaultOptionsToken.optional,
   },
   provides({
@@ -92,6 +109,7 @@ const ApolloClientPlugin: FusionPlugin<
     apolloContext = ctx => ctx,
     getApolloLinks,
     schema,
+    resolvers,
     defaultOptions,
   }) {
     function getClient(ctx, initialState) {
@@ -140,6 +158,7 @@ const ApolloClientPlugin: FusionPlugin<
         connectToDevTools: __BROWSER__ && __DEV__,
         link: apolloLinkFrom(links),
         cache: cache.restore(initialState),
+        resolvers,
         defaultOptions,
       });
       return client;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,11 +1335,6 @@
     "@babel/helper-replace-supers" "^7.0.0"
     "@babel/plugin-syntax-class-properties" "^7.0.0"
 
-"@types/async@2.0.50":
-  version "2.0.50"
-  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.50.tgz#117540e026d64e1846093abbd5adc7e27fda7bcb"
-  integrity sha512-VMhZMMQgV1zsR+lX/0IBfAk+8Eb7dPVMWiQGFAt3qjo5x7Ml6b77jUo0e1C3ToD+XRDXqtrfw+6AB0uUsPEr3Q==
-
 "@types/core-js@^0.9.41":
   version "0.9.46"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"
@@ -1705,27 +1700,35 @@ apollo-cache-inmemory@^1.3.12:
     apollo-utilities "^1.0.27"
     optimism "^0.6.8"
 
-apollo-cache@1.1.22, apollo-cache@^1.1.22:
+apollo-cache@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.2.1.tgz#aae71eb4a11f1f7322adc343f84b1a39b0693644"
+  integrity sha512-nzFmep/oKlbzUuDyz6fS6aYhRmfpcHWqNkkA9Bbxwk18RD6LXC4eZkuE0gXRX0IibVBHNjYVK+Szi0Yied4SpQ==
+  dependencies:
+    apollo-utilities "^1.2.1"
+    tslib "^1.9.3"
+
+apollo-cache@^1.1.22:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.22.tgz#d4682ea6e8b2508a934f61c2fd9e36b4a65041d9"
   integrity sha512-8PoxhQLISj2oHwT7i/r4l+ly4y3RKZls+dtXzAewu3U77P9dNZKhYkRNAhx9iEfsrNoHgXBV8vMp64hb1uYh+g==
   dependencies:
     apollo-utilities "^1.0.27"
 
-apollo-client@^2.4.8:
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.4.8.tgz#3a798f1076243465a59061d44d11bd030b68deb9"
-  integrity sha512-OAFbCTnGPtaIv0j+EZYzY20d+MD2JNbJ/YXZ4s0/oZlSg87bb0gjcIbccw2lnytipymZcZNr5ArFFeh0saGEwA==
+apollo-client@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.5.1.tgz#36126ed1d32edd79c3713c6684546a3bea80e6d1"
+  integrity sha512-MNcQKiqLHdGmNJ0rZ0NXaHrToXapJgS/5kPk0FygXt+/FmDCdzqcujI7OPxEC6e9Yw5S/8dIvOXcRNuOMElHkA==
   dependencies:
     "@types/zen-observable" "^0.8.0"
-    apollo-cache "1.1.22"
+    apollo-cache "1.2.1"
     apollo-link "^1.0.0"
     apollo-link-dedup "^1.0.0"
-    apollo-utilities "1.0.27"
+    apollo-utilities "1.2.1"
     symbol-observable "^1.0.2"
+    ts-invariant "^0.2.1"
+    tslib "^1.9.3"
     zen-observable "^0.8.0"
-  optionalDependencies:
-    "@types/async" "2.0.50"
 
 apollo-link-dedup@^1.0.0:
   version "1.0.13"
@@ -1793,7 +1796,16 @@ apollo-tracing@^0.1.0:
   dependencies:
     graphql-extensions "~0.0.9"
 
-apollo-utilities@1.0.27, apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.27:
+apollo-utilities@1.2.1, apollo-utilities@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.2.1.tgz#1c3a1ebf5607d7c8efe7636daaf58e7463b41b3c"
+  integrity sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
+    ts-invariant "^0.2.1"
+    tslib "^1.9.3"
+
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.27:
   version "1.0.27"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.27.tgz#77c550f9086552376eca3a48e234a1466b5b057e"
   integrity sha512-nzrMQ89JMpNmYnVGJ4t8zN75gQbql27UDhlxNi+3OModp0Masx5g+fQmQJ5B4w2dpRuYOsdwFLmj3lQbwOKV1Q==
@@ -9757,7 +9769,14 @@ triple-beam@^1.2.0, triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
-tslib@^1.9.0:
+ts-invariant@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.2.1.tgz#3d587f9d6e3bded97bf9ec17951dd9814d5a9d3f"
+  integrity sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==
+  dependencies:
+    tslib "^1.9.3"
+
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
The new version of Apollo Client (2.5.1) has local state management capabilities built-in. The package `apollo-link-state`, which was previously used for this, is now deprecated.

This PR upgrades Apollo Client to the newest version and allows to specify the resolvers for local state management.

For details see: https://www.apollographql.com/docs/react/essentials/local-state.html